### PR TITLE
Update compat bounds for current upstream versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [compat]
 CodecZlib = "0.6, 0.7"
 julia = "1"
-DataStructures = "0.17, 0.18"
+DataStructures = "0.17, 0.18, 0.19"
 WeakRefStrings = "0.5, 0.6, 1"
 DoubleFloats = "0.9, 1"
 Nullables = "0.0.7, 0.0.8, 1"


### PR DESCRIPTION
Widens compat so the package admits the current upstream releases:

- DataStructures: admit 0.19

Verified locally: the test environment resolves the newest admitted versions (e.g. JSON 1.7.1, DataStructures 0.19.6, FilePaths 0.9.0) and all test items pass. Supersedes the corresponding dependabot compat PRs, which will close themselves once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
