### PR TITLE
Add a pluggable sink for missing-value columns

### DIFF
--- a/src/csv.jl
+++ b/src/csv.jl
@@ -72,6 +72,7 @@ Read CSV from `file`. Returns a tuple of 2 elements:
 - `skiplines_begin`: skips specified number of lines at the beginning of the file
 - `header_exists`: boolean specifying whether CSV file contains a header
 - `nastrings`: strings that are to be considered NA. Defaults to `TextParse.NA_STRINGS`
+- `missingarraytype`: the output vector type for columns that contain missing values. Defaults to `Array` (columns come back as `Array{Union{Missing,T}}`). A package can plug in its own column type by implementing `allocmissing`, `setmissing!`, `promotemissing`, `ismissingcolumn` and `colmatchestype` for its type; requires `stringarraytype=Array`.
 - `colnames`: manually specified column names. Could be a vector or a dictionary from Int index (the column) to String column name.
 - `colparsers`: Parsers to use for specified columns. This can be a vector or a dictionary from column name / column index (Int) to a "parser". The simplest parser is a type such as Int, Float64. It can also be a `dateformat"..."`, see [CustomParser](@ref) if you want to plug in custom parsing behavior. If you pass `nothing` as the parser for a given column, that column will be skipped
 - `type_detect_rows`: number of rows to use to infer the initial `colparsers` defaults to 20.
@@ -176,6 +177,7 @@ function _csvread_internal(str::AbstractString, delim=',';
                  commentchar=nothing,
                  stringtype=String,
                  stringarraytype=StringArray,
+                 missingarraytype=Array,
                  noresize=false,
                  rowno::Int=1,
                  prevheaders=nothing,
@@ -196,6 +198,9 @@ function _csvread_internal(str::AbstractString, delim=',';
 
     if pooledstrings === true
         @warn("pooledstrings argument has been removed")
+    end
+    if missingarraytype !== Array && stringarraytype !== Array
+        throw(ArgumentError("missingarraytype sinks require stringarraytype=Array"))
     end
     opts = LocalOpts(isascii(delim) ? UInt8(delim) : delim, spacedelim,
         isascii(quotechar) ? UInt8(quotechar) : quotechar,
@@ -297,7 +302,7 @@ function _csvread_internal(str::AbstractString, delim=',';
 
     if isempty(colspool)
         # this is the first file, use row_estimate
-        cols = makeoutputvecs(rec, row_estimate, stringtype, stringarraytype)
+        cols = makeoutputvecs(rec, row_estimate, stringtype, stringarraytype, missingarraytype)
         for (c2, h) in zip(cols, canonnames)
             colspool[h] = c2
         end
@@ -306,28 +311,30 @@ function _csvread_internal(str::AbstractString, delim=',';
             c = get(canonnames, i, i)
             f = rec.fields[i]
             if haskey(colspool, c)
-                if eltype(colspool[c]) == fieldtype(f) || (fieldtype(f) <: StrRange && eltype(colspool[c]) <: AbstractString) || colspool[c]===nothing
+                if colmatchestype(colspool[c], fieldtype(f)) || (fieldtype(f) <: StrRange && eltype(colspool[c]) <: AbstractString) || colspool[c]===nothing
                     return colspool[c]
                 else
                     try
                         return colspool[c] = promote_column(colspool[c],
                                                             rowno-1,
-                                                            fieldtype(f), stringtype, stringarraytype)
+                                                            fieldtype(f), stringtype, stringarraytype,
+                                                            missingarraytype)
                     catch err
                         error("Could not convert column $c of eltype $(eltype(colspool[c])) to eltype $(fieldtype(f))")
                     end
                 end
             else
-                return colspool[c] = makeoutputvec(f, row_estimate, stringtype, stringarraytype)
+                return colspool[c] = makeoutputvec(f, row_estimate, stringtype, stringarraytype, missingarraytype)
             end
         end
         # promote missing columns to nullable
         missingcols = setdiff(collect(keys(colspool)), canonnames)
         for k in missingcols
-            if !ismissingtype(eltype(colspool[k])) && !(eltype(colspool[k]) <: StringLike)
+            if !ismissingcolumn(colspool[k]) && !(eltype(colspool[k]) <: StringLike)
                 colspool[k] = promote_column(colspool[k],
                                              rowno-1,
-                                             UnionMissing{eltype(colspool[k])}, stringtype, stringarraytype)
+                                             UnionMissing{eltype(colspool[k])}, stringtype, stringarraytype,
+                                             missingarraytype)
             end
         end
         cols = (_cols...,)
@@ -399,7 +406,7 @@ function _csvread_internal(str::AbstractString, delim=',';
                 col = cols[colidx]
                 f = rec.fields[colidx]
                 name = get(canonnames, colidx, colidx)
-                c = promote_field(s, f, col, err, nastrings, stringtype, stringarraytype, opts)
+                c = promote_field(s, f, col, err, nastrings, stringtype, stringarraytype, missingarraytype, opts)
                 if c[2]==:reparserequired
                     reparse_needed[colidx] = true
                     c = c[1], stringarraytype{stringtype,1}(undef, row_estimate)
@@ -413,7 +420,7 @@ function _csvread_internal(str::AbstractString, delim=',';
                 new_fields[end] = swapinner(new_fields[end], new_fields[end], eoldelim=true)
                 rec2 = Record((new_fields...,))
 
-                cols2 = makeoutputvecs(rec2, row_estimate, stringtype, stringarraytype)
+                cols2 = makeoutputvecs(rec2, row_estimate, stringtype, stringarraytype, missingarraytype)
                 for (iii, val) in enumerate(cols2)
                     if val!==nothing
                         colspool[iii] = val
@@ -464,7 +471,7 @@ function _csvread_internal(str::AbstractString, delim=',';
     cols, canonnames, parsers, finalrows
 end
 
-function promote_field(failed_str, field, col, err, nastrings, stringtype, stringarraytype, opts)
+function promote_field(failed_str, field, col, err, nastrings, stringtype, stringarraytype, missingarraytype, opts)
     if field.inner isa SkipToken
         # No need to change
         return field, col
@@ -478,7 +485,7 @@ function promote_field(failed_str, field, col, err, nastrings, stringtype, strin
         return swapinner(field, newtoken), :reparserequired
     end
     newcol = try
-        promote_column(col,  err.rowno-1, fieldtype(newtoken), stringtype, stringarraytype)
+        promote_column(col,  err.rowno-1, fieldtype(newtoken), stringtype, stringarraytype, missingarraytype)
     catch err2
         # TODO Should this really be shown?
         Base.showerror(stderr, err2)
@@ -488,7 +495,7 @@ function promote_field(failed_str, field, col, err, nastrings, stringtype, strin
     swapinner(field, newtoken), newcol
 end
 
-function promote_column(col, rowno, T, stringtype, stringarraytype, inner=false)
+function promote_column(col, rowno, T, stringtype, stringarraytype, missingarraytype=Array, inner=false)
     if typeof(col) <: Array{Missing}
         if T <: StringLike
             arr = stringarraytype{stringtype,1}(undef, length(col))
@@ -497,17 +504,12 @@ function promote_column(col, rowno, T, stringtype, stringarraytype, inner=false)
             end
             return arr
         elseif ismissingtype(T)
-            fill!(Array{UnionMissing{eltype(T)}}(undef, length(col)), missing) # defaults to fill missing
+            return promotemissing(missingarraytype, col, rowno, T)
         else
             error("empty to non-nullable")
         end
     elseif ismissingtype(T)
-        arr = convert(Array{UnionMissing{T}}, col)
-        for i=rowno+1:length(arr)
-            # if we convert an Array{Int} to be missing-friendly, we will not have missing in here by default
-            arr[i] = missing
-        end
-        return arr
+        return promotemissing(missingarraytype, col, rowno, T)
     else
         newcol = Array{T, 1}(undef, length(col))
         copyto!(newcol, 1, col, 1, rowno)
@@ -648,11 +650,11 @@ function resizecols(colspool, nrecs)
     end
 end
 
-function makeoutputvecs(rec, N, stringtype, stringarraytype)
-    map(f->makeoutputvec(f, N, stringtype, stringarraytype), rec.fields)
+function makeoutputvecs(rec, N, stringtype, stringarraytype, missingarraytype=Array)
+    map(f->makeoutputvec(f, N, stringtype, stringarraytype, missingarraytype), rec.fields)
 end
 
-function makeoutputvec(eltyp, N, stringtype, stringarraytype)
+function makeoutputvec(eltyp, N, stringtype, stringarraytype, missingarraytype=Array)
     if fieldtype(eltyp)===Nothing
         return nothing
     elseif fieldtype(eltyp) == Missing # we weren't able to detect the type,
@@ -662,10 +664,68 @@ function makeoutputvec(eltyp, N, stringtype, stringarraytype)
         stringarraytype{stringtype,1}(undef, N)
     elseif ismissingtype(fieldtype(eltyp)) && fieldtype(eltyp) <: StrRange
         stringarraytype{Union{Missing, String},1}(undef, N)
+    elseif ismissingtype(fieldtype(eltyp)) && missingarraytype !== Array
+        allocmissing(missingarraytype, Base.nonmissingtype(fieldtype(eltyp)), N)
     else
         Array{fieldtype(eltyp)}(undef, N)
     end
 end
+
+# ---------------------------------------------------------------------------
+# The pluggable missing-value sink API.
+#
+# `csvread(...; missingarraytype=MA)` makes the parser store missing-capable
+# columns in the caller's own column type instead of Array{Union{Missing,T}},
+# without TextParse depending on that type's package. A sink `MA` implements
+# the functions below plus `setmissing!` (record.jl); its columns must also
+# support `setindex!` with plain values, `resize!`, and `length`.
+# Requires `stringarraytype=Array`.
+# ---------------------------------------------------------------------------
+
+"""
+    allocmissing(::Type{MA}, ::Type{T}, N)
+
+Allocate the length-`N` output vector for a column with value type `T` in
+which missing values may occur, under `missingarraytype=MA`. The default
+`Array` sink allocates `Array{Union{Missing,T}}`.
+"""
+allocmissing(::Type{Array}, ::Type{T}, N) where {T} = Array{UnionMissing{T}}(undef, N)
+
+"""
+    promotemissing(::Type{MA}, col, rowno, ::Type{T})
+
+Convert output column `col`, whose first `rowno` entries hold parsed values,
+into the missing-capable column for target type `T` (`T` includes `Missing`),
+under `missingarraytype=MA`. `col` is an `Array{Missing}` when every cell so
+far was blank, a plain `Vector` when the first missing value was just
+encountered, or an already-allocated sink column that needs widening.
+"""
+function promotemissing(::Type{Array}, col::Array{Missing}, rowno, ::Type{T}) where {T}
+    return fill!(Array{UnionMissing{eltype(T)}}(undef, length(col)), missing) # defaults to fill missing
+end
+function promotemissing(::Type{Array}, col::AbstractVector, rowno, ::Type{T}) where {T}
+    arr = convert(Array{UnionMissing{T}}, col)
+    for i=rowno+1:length(arr)
+        # if we convert an Array{Int} to be missing-friendly, we will not have missing in here by default
+        arr[i] = missing
+    end
+    return arr
+end
+
+"""
+    ismissingcolumn(col)
+
+Whether output column `col` can already hold missing values.
+"""
+ismissingcolumn(col) = ismissingtype(eltype(col))
+
+"""
+    colmatchestype(col, ::Type{T})
+
+Whether output column `col` can be reused as-is for a field whose parsed
+value type is `T`.
+"""
+colmatchestype(col, ::Type{T}) where {T} = eltype(col) == T
 
 
 mutable struct CSVParseError <: Exception

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -74,7 +74,7 @@ Read CSV from `file`. Returns a tuple of 2 elements:
 - `nastrings`: strings that are to be considered NA. Defaults to `TextParse.NA_STRINGS`
 - `missingarraytype`: the output vector type for columns that contain missing values. Defaults to `Array` (columns come back as `Array{Union{Missing,T}}`). A package can plug in its own column type by implementing `allocmissing`, `setmissing!`, `promotemissing`, `ismissingcolumn` and `colmatchestype` for its type; requires `stringarraytype=Array`.
 - `colnames`: manually specified column names. Could be a vector or a dictionary from Int index (the column) to String column name.
-- `colparsers`: Parsers to use for specified columns. This can be a vector or a dictionary from column name / column index (Int) to a "parser". The simplest parser is a type such as Int, Float64. It can also be a `dateformat"..."`, see [CustomParser](@ref) if you want to plug in custom parsing behavior. If you pass `nothing` as the parser for a given column, that column will be skipped
+- `colparsers`: Parsers to use for specified columns. This can be a vector or a dictionary from column name / column index (Int) to a "parser". The simplest parser is a type such as Int, Float64. It can also be a `dateformat"..."`, see [`CustomParser`](@ref) if you want to plug in custom parsing behavior. If you pass `nothing` as the parser for a given column, that column will be skipped
 - `type_detect_rows`: number of rows to use to infer the initial `colparsers` defaults to 20.
 """
 function csvread(file::String, delim=','; kwargs...)

--- a/src/record.jl
+++ b/src/record.jl
@@ -90,10 +90,26 @@ end
     end
 end
 
+"""
+    setmissing!(col, i)
+
+Record a missing value at index `i` of output column `col`. The default
+writes `missing`; a `missingarraytype` sink (see csv.jl) overloads this to
+store its own missing representation.
+"""
+@inline setmissing!(col, i) = (col[i] = missing; nothing)
+
 @inline function setcell!(col, i, val, str)
     col[i] = val
     PARSE_SUCCESS
 end
+
+@inline function setcell!(col, i, val::Missing, str)
+    setmissing!(col, i)
+    PARSE_SUCCESS
+end
+
+@inline setcell!(col::Nothing, i, val::Missing, str) = PARSE_SUCCESS
 
 @inline function setcell!(col::Nothing, i, val, str)
     PARSE_SUCCESS

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,6 @@ using TestItemRunner
 
 include("test_textparse.jl")
 include("test_vectorbackedstrings.jl")
+include("test_missing_sink.jl")
 
 @run_package_tests

--- a/test/test_missing_sink.jl
+++ b/test/test_missing_sink.jl
@@ -1,0 +1,99 @@
+@testitem "pluggable missing sink" begin
+    # A minimal values+mask sink implementing the missingarraytype contract,
+    # defined here without any external package.
+    struct MaskVector{T} <: AbstractVector{T}
+        values::Vector{T}
+        isna::Vector{Bool}
+    end
+    Base.size(v::MaskVector) = size(v.values)
+    Base.getindex(v::MaskVector, i::Int) = v.isna[i] ? nothing : v.values[i]
+    Base.setindex!(v::MaskVector{T}, x, i::Int) where {T} =
+        (v.values[i] = x; v.isna[i] = false; x)
+    function Base.resize!(v::MaskVector, n::Integer)
+        l = length(v.values)
+        resize!(v.values, n)
+        resize!(v.isna, n)
+        for i = l+1:n
+            v.isna[i] = true
+        end
+        return v
+    end
+
+    TextParse.allocmissing(::Type{MaskVector}, ::Type{T}, N) where {T} =
+        MaskVector{T}(Vector{T}(undef, N), fill(true, N))
+    TextParse.setmissing!(v::MaskVector, i) = (v.isna[i] = true; nothing)
+    TextParse.ismissingcolumn(::MaskVector) = true
+    TextParse.colmatchestype(v::MaskVector{T}, ::Type{S}) where {T,S} =
+        S == Union{Missing,T}
+    function TextParse.promotemissing(::Type{MaskVector}, col::Array{Missing}, rowno, ::Type{T}) where {T}
+        S = Base.nonmissingtype(T)
+        S === Any && (S = Missing)
+        return MaskVector{S}(Vector{S}(undef, length(col)), fill(true, length(col)))
+    end
+    function TextParse.promotemissing(::Type{MaskVector}, col::Vector{S}, rowno, ::Type{T}) where {S,T}
+        VT = Base.nonmissingtype(T)
+        values = Vector{VT}(undef, length(col))
+        isna = fill(true, length(col))
+        for i = 1:rowno
+            values[i] = col[i]
+            isna[i] = false
+        end
+        return MaskVector{VT}(values, isna)
+    end
+    function TextParse.promotemissing(::Type{MaskVector}, col::MaskVector{S}, rowno, ::Type{T}) where {S,T}
+        VT = Base.nonmissingtype(T)
+        VT === S && return col
+        values = Vector{VT}(undef, length(col.values))
+        for i = 1:rowno
+            col.isna[i] || (values[i] = col.values[i])
+        end
+        return MaskVector{VT}(values, copy(col.isna))
+    end
+
+    # Column that is nullable from the start (NA in the type-detect window)
+    data = """
+    a,b,c
+    1,x,1.5
+    NA,y,2.5
+    3,NA,NA
+    """
+    cols, names = TextParse._csvread(data, ','; stringarraytype=Array, missingarraytype=MaskVector)
+    @test names == ["a", "b", "c"]
+    a, b, c = cols
+    @test a isa MaskVector{Int}
+    @test a.isna == [false, true, false]
+    @test a.values[1] == 1 && a.values[3] == 3
+    # "NA" in a string column is a valid string, not a missing value
+    @test b isa Vector{String}
+    @test b == ["x", "y", "NA"]
+    @test c isa MaskVector{Float64}
+    @test c.isna == [false, false, true]
+    @test c.values[2] == 2.5
+
+    # Late promotion: the first missing value appears after the type-detect
+    # window, so a plain Vector{Int} column is promoted into the sink mid-parse.
+    n = 60
+    rows = [string(i) for i in 1:n]
+    rows[50] = "NA"
+    data2 = "a\n" * join(rows, "\n") * "\n"
+    cols2, _ = TextParse._csvread(data2, ','; stringarraytype=Array, missingarraytype=MaskVector)
+    col2 = cols2[1]
+    @test col2 isa MaskVector{Int}
+    @test length(col2.values) == n
+    @test col2.isna[50]
+    @test count(col2.isna) == 1
+    @test col2.values[49] == 49 && col2.values[51] == 51
+
+    # Columns without missing values stay plain Vectors
+    cols3, _ = TextParse._csvread("a,b\n1,x\n2,y\n", ','; stringarraytype=Array, missingarraytype=MaskVector)
+    @test cols3[1] isa Vector{Int}
+    @test cols3[2] isa Vector{String}
+
+    # Guard: plugin sinks require stringarraytype=Array
+    @test_throws ArgumentError TextParse._csvread("a\n1\n", ','; missingarraytype=MaskVector)
+
+    # Defaults unchanged: no sink argument gives Union{Missing,T} columns
+    cols4, _ = TextParse._csvread(data, ','; stringarraytype=Array)
+    @test eltype(cols4[1]) == Union{Missing,Int}
+    @test ismissing(cols4[1][2])
+end


### PR DESCRIPTION
`csvread` gains a `missingarraytype` keyword (default `Array` — behavior unchanged, the defaults reproduce the previous code paths exactly) that selects the output vector type for columns containing missing values. A package can have the parser write **straight into its own column type** — no `Union{Missing,T}` arrays anywhere and no post-parse conversion — by implementing five small functions for its type:

- `allocmissing(::Type{MA}, ::Type{T}, N)` — allocate a missing-capable column
- `setmissing!(col, i)` — record a missing cell
- `promotemissing(::Type{MA}, col, rowno, ::Type{T})` — mid-parse promotion when the first missing value (or a wider value type) appears after the type-detect window
- `ismissingcolumn(col)` / `colmatchestype(col, T)` — column reuse checks

TextParse itself takes **no new dependencies**. The parse kernels already specialize on the concrete column types in the output tuple, so a plugin sink compiles its own type-stable kernels; `setcell!` remains the single write seam, with missing values now routed through `setmissing!`. Plugin sinks require `stringarraytype=Array` (enforced with an `ArgumentError`); the multi-file `colspool` reuse path is wired through but only the single-source path is exercised by tests so far.

The new testitem proves the contract with a dummy values+mask sink defined entirely in the test — early-nullable columns, mid-parse promotion (first NA after the type-detect window), NA-free columns staying plain `Vector`s, the `stringarraytype` guard, and defaults-unchanged regression.

The immediate consumer is CSVFiles, which plugs in `DataValues.DataValueArray` so Queryverse consumers receive DataValue-based columns directly from the parser (companion PR there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)